### PR TITLE
Fix compilation error (Arduino IDE v2.1.0 with XIAO_ESP32C3)

### DIFF
--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -829,7 +829,7 @@ void AsyncWebSocketClient::binary(AsyncWebSocketMessageBuffer * buffer)
 
 IPAddress AsyncWebSocketClient::remoteIP() {
     if(!_client) {
-        return IPAddress(0U);
+        return IPAddress(static_cast<uint32_t>(0U));
     }
     return _client->remoteIP();
 }


### PR DESCRIPTION
I was getting the error message below:

```cpp
/home/xxx/Arduino/libraries/ESPAsyncWebSrv/src/AsyncWebSocket.cpp:832:28: error: call of overloaded 'IPAddress(unsigned int)' is ambiguous
         return IPAddress(0U);
```

So I added a static cast. Could you merge this ASAP? We are using the library in a course and would be nice to have the fix up.
