### PR TITLE
Release 1.2.7 not synced to Arduino Library Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ESPAsyncWebServer 
 
+***ERROR: Release 1.2.7 not synced to Arduino Library Registry!***
+
 Async HTTP and WebSocket Server for ESP8266 Arduino
 
 For ESP8266 it requires [ESPAsyncTCP](https://github.com/dvarrel/ESPAsyncTCP)


### PR DESCRIPTION
Release 1.2.7 is not picked up by Arduino Library Registry. 
Details: [Logs from the Library Manager indexer](https://downloads.arduino.cc/libraries/logs/github.com/dvarrel/ESPAsyncWebSrv/)